### PR TITLE
Make this repository compatible with test262-harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+harness/*.js
+!harness/Membrane.js

--- a/README.md
+++ b/README.md
@@ -4,3 +4,23 @@
 
 This repository contains integration tests for [the current draft](https://tc39.github.io/ecma262/) of [ECMA-262](https://github.com/tc39/ecma262),
 the ECMAScript® Language Specification.
+
+
+## Harness
+
+To run tests from this repository using test262-harness, harness helper files must be sync'ed from Test262: 
+
+```
+./scripts/sync-harness.sh
+```
+
+or 
+
+```
+npm run sync-harness
+```
+
+
+## Interpreting
+
+The verion number in [package.json](https://github.com/tc39/test262-integration/blob/master/package.json) cooresponds to Test262's version number, which indicates the expected [INTERPRETING.md](https://github.com/tc39/test262/blob/master/INTERPRETING.md) semantics.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test262-integration",
+  "version": "3.0.0",
+  "description": "Test262 Integration tests novel feature integrations and use cases.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tc39/test262-integration.git"
+  },
+  "license": "BSD",
+  "bugs": {
+    "url": "https://github.com/tc39/test262-integration/issues"
+  },
+  "private": true,
+  "homepage": "https://github.com/tc39/test262-integration#readme",
+  "scripts": {
+    "sync-harness": "./scripts/sync-harness.sh"
+  }
+}

--- a/scripts/sync-harness.sh
+++ b/scripts/sync-harness.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+TARGET_ROOT_PATH=$(pwd)
+TARGET_HARNESS_PATH=$TARGET_ROOT_PATH/harness
+TEMP_PATH=$(mktemp -d -t "test262.XXXXXXXX")
+TEST262_ROOT_PATH=$TEMP_PATH/test262
+TEST262_HARNESS_PATH=$TEST262_ROOT_PATH/harness
+
+echo "Moving into $TEMP_PATH"
+cd $TEMP_PATH
+
+git clone https://github.com/tc39/test262.git --depth=1
+
+echo "Moving into $TEST262_HARNESS_PATH"
+cd $TEST262_HARNESS_PATH
+
+echo "Copying files from $TEST262_HARNESS_PATH into $TARGET_HARNESS_PATH"
+cp -f *.js $TARGET_HARNESS_PATH
+
+echo "Returing to $TARGET_ROOT_PATH"
+cd $TARGET_ROOT_PATH
+
+echo "Harness helper file sync is complete"


### PR DESCRIPTION
- Adds a package.json, which is necessary to provide the version number used to validate the Test262 INTERPRETING.md semantics.
- Adds a script to sync the test262/harness files that test262-harness depends on for building standalone runtimes (ie. assert.js, sta.js and doneprintHandle.js)
- Adds instructions to README.md
- Adds .gitignore with pattern to ignore harness files that should not be committed to this repository.


-------------------------------------------------------------------------


Here's the outcome of running this repository's tests with test262-harness: 


```
-----------------------------------------------------------------------------------------
V8 (jsvu)

test262-harness --hostType=d8 --hostPath=/Users/rwaldron/.jsvu/v8 test/Membrane/accessor-descriptor.js test/Membrane/call-constructor.js test/Membrane/call-method.js test/Membrane/delete-property.js test/Membrane/direct-wrap.js test/Membrane/lookup-null.js test/Membrane/not-configurable-nor-writable.js test/Membrane/property-cycle-lookup.js test/Membrane/property-identity.js test/Membrane/prototype.js test/Membrane/same-graph-setter.js test/Membrane/set-property-extensible.js

Ran 24 tests
24 passed
0 failed

-----------------------------------------------------------------------------------------
ChakraCore (jsvu)

test262-harness --hostType=ch --hostPath=/Users/rwaldron/.jsvu/chakra test/Membrane/accessor-descriptor.js test/Membrane/call-constructor.js test/Membrane/call-method.js test/Membrane/delete-property.js test/Membrane/direct-wrap.js test/Membrane/lookup-null.js test/Membrane/not-configurable-nor-writable.js test/Membrane/property-cycle-lookup.js test/Membrane/property-identity.js test/Membrane/prototype.js test/Membrane/same-graph-setter.js test/Membrane/set-property-extensible.js

Ran 24 tests
24 passed
0 failed

-----------------------------------------------------------------------------------------
JavaScriptCore (jsvu)

test262-harness --hostType=jsc --hostPath=/Users/rwaldron/.jsvu/javascriptcore test/Membrane/accessor-descriptor.js test/Membrane/call-constructor.js test/Membrane/call-method.js test/Membrane/delete-property.js test/Membrane/direct-wrap.js test/Membrane/lookup-null.js test/Membrane/not-configurable-nor-writable.js test/Membrane/property-cycle-lookup.js test/Membrane/property-identity.js test/Membrane/prototype.js test/Membrane/same-graph-setter.js test/Membrane/set-property-extensible.js

Ran 24 tests
24 passed
0 failed

-----------------------------------------------------------------------------------------
SpiderMonkey (jsvu)

test262-harness --hostType=jsshell --hostPath=/Users/rwaldron/.jsvu/sm test/Membrane/accessor-descriptor.js test/Membrane/call-constructor.js test/Membrane/call-method.js test/Membrane/delete-property.js test/Membrane/direct-wrap.js test/Membrane/lookup-null.js test/Membrane/not-configurable-nor-writable.js test/Membrane/property-cycle-lookup.js test/Membrane/property-identity.js test/Membrane/prototype.js test/Membrane/same-graph-setter.js test/Membrane/set-property-extensible.js

Ran 24 tests
24 passed
0 failed

-----------------------------------------------------------------------------------------
Moddable (jsvu)

test262-harness --hostType=xs --hostPath=/Users/rwaldron/.jsvu/xs test/Membrane/accessor-descriptor.js test/Membrane/call-constructor.js test/Membrane/call-method.js test/Membrane/delete-property.js test/Membrane/direct-wrap.js test/Membrane/lookup-null.js test/Membrane/not-configurable-nor-writable.js test/Membrane/property-cycle-lookup.js test/Membrane/property-identity.js test/Membrane/prototype.js test/Membrane/same-graph-setter.js test/Membrane/set-property-extensible.js

FAIL test/Membrane/delete-property.js (default)
  Expected no error, got TypeError: Array.prototype.forEach: callback is no function

FAIL test/Membrane/delete-property.js (strict mode)
  Expected no error, got TypeError: Array.prototype.forEach: callback is no function

FAIL test/Membrane/not-configurable-nor-writable.js (default)
  Expected no error, got TypeError: Array.prototype.forEach: callback is no function

FAIL test/Membrane/not-configurable-nor-writable.js (strict mode)
  Expected no error, got TypeError: Array.prototype.forEach: callback is no function

FAIL test/Membrane/prototype.js (default)
  Expected no error, got TypeError: Array.prototype.forEach: callback is no function

FAIL test/Membrane/prototype.js (strict mode)
  Expected no error, got TypeError: Array.prototype.forEach: callback is no function

Ran 24 tests
18 passed
6 failed
```